### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -24,5 +24,4 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :deliveryfee_id, :area_id, :days_id, :price,
                                  :image).merge(user_id: current_user.id)
   end
-
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,26 @@
+      <li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag(item.image, class: "item-img" ) %>
+
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div> %>
+          <%# //商品が売れていればsold outを表示しましょう %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= item.name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= item.price %>円<br><%= item.deliveryfee.name %></span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,29 +126,28 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%= render partial: "item", collection: @items, locals: { deliveryfee: @deliveryfee } %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items.present? %> 
+        <%= render partial: "item", collection: @items %>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,37 +123,10 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%= render partial: "item", collection: @items, locals: { deliveryfee: @deliveryfee } %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'priceが¥300~¥9,999,999の間であり、半角数字で入力されていれば登録できる' do
-        @item.price = 100000
+        @item.price = 100_000
         expect(@item).to be_valid
       end
     end
@@ -87,19 +87,19 @@ RSpec.describe Item, type: :model do
       it 'priceが半角英数混合では登録できない' do
         @item.price = '12as12'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price 半角数字で入力してください")
+        expect(@item.errors.full_messages).to include('Price 半角数字で入力してください')
       end
 
       it 'priceが半角英語だけでは登録できない' do
         @item.price = 'price'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price 半角数字で入力してください")
+        expect(@item.errors.full_messages).to include('Price 半角数字で入力してください')
       end
 
       it 'priceが¥10,000,000以上では登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price ¥300〜9,999,999内で入力してください")
+        expect(@item.errors.full_messages).to include('Price ¥300〜9,999,999内で入力してください')
       end
 
       it 'userが紐付いていないと保存できないこと' do


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
商品一覧を表示するため

- 商品がない時はダミー画像が表示される
https://gyazo.com/52e2c3110a4f151a8e293c750f692739

-出品された日時が新しい順に上から表示されること 
https://gyazo.com/79d2c75615e7f73652ed59cc337a96bb

- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/5ba2193c0990e520f6df36702956cf31